### PR TITLE
Add spritesheet url to allow external spritesheet

### DIFF
--- a/config/blade-svg.php
+++ b/config/blade-svg.php
@@ -3,6 +3,7 @@
 return [
     'icon_path' => 'path/to/icons',
     'spritesheet_path' => 'path/to/spritesheet',
+    'spritesheet_url' => '',
     'inline' => false,
     'class' => 'icon',
 ];

--- a/src/Icon.php
+++ b/src/Icon.php
@@ -62,8 +62,9 @@ class Icon implements Htmlable
 
     public function renderFromSprite()
     {
-        return vsprintf('<svg%s><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#%s"></use></svg>', [
+        return vsprintf('<svg%s><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="%s#%s"></use></svg>', [
             $this->renderAttributes(),
+            $this->factory->spritesheetUrl(),
             $this->factory->spriteId($this->icon)
         ]);
     }

--- a/src/IconFactory.php
+++ b/src/IconFactory.php
@@ -46,6 +46,11 @@ class IconFactory
         });
     }
 
+    public function spritesheetUrl()
+    {
+        return $this->config->get('spritesheet_url', '');
+    }
+
     public function spritesheet()
     {
         return new HtmlString(


### PR DESCRIPTION
Maybe you want that the  spritesheet was loaded from an external file, this is great if you want use,  for example, the browser cache, external files doesn't work with some versions of internet explorer but there are some fixs in the web, or maybe you don't need ie compatibility.
