### PR TITLE
Remove the assets subdir from config defaults

### DIFF
--- a/config/blade-svg.php
+++ b/config/blade-svg.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'svg_path' => 'resources/assets/svg',
+    'svg_path' => 'resources/svg',
 
     /*
     |--------------------------------------------------------------------------
@@ -26,7 +26,7 @@ return [
     |
     */
 
-    'spritesheet_path' => 'resources/assets/svg/spritesheet.svg',
+    'spritesheet_path' => 'resources/svg/spritesheet.svg',
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Laravel 5.7 flattened the resources directory, this patch updates the config file to reflect the changes.

https://laravel.com/docs/5.7/upgrade#upgrade-5.7.0