### PR TITLE
Update readme to reflect auto-registering service provider

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,23 +10,7 @@ You can install this package via Composer by running this command in your termin
 
 ## Getting started
 
-Add the Blade SVG service provider to your `config/app.php` file:
-
-```php
-<?php
-
-return [
-    // ...
-    'providers' => [
-        // ...
-
-        BladeSvg\BladeSvgServiceProvider::class,
-
-        // ...
-    ],
-    // ...
-];
-```
+The package's service provider will automatically register itself.
 
 Publish the Blade SVG config file:
 


### PR DESCRIPTION
Me: Do I really have to register the service provider myself like the pioneers used to do?

Me: I better just check first and see if it auto-registers.

Me: Ok, phew, it does.

Me: I should PR this to save thousands of developers from the same toils.

Also, I actually came here to PR a change to the config to reflect the new `resources` directory stuff: `resources/assets` -> `resources/`. But it looks like someone already did, but change isn't tagged...

...you should tag it...