### PR TITLE
Add blade-tabler-icons to third party list

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ We're not accepting requests to build new icon packages ourselves but you can [s
 - [Blade Feather Icons](https://github.com/brunocfalcao/blade-feather-icons)
 - [Blade Font Awesome](https://github.com/owenvoke/blade-fontawesome)
 - [Blade Github Octicons](https://github.com/Activisme-be/Blade-github-octicons)
+- [Blade Tabler Icons](https://github.com/ryangjchandler/blade-tabler-icons)
 
 ## Requirements
 


### PR DESCRIPTION
This PR adds my [`ryangjchandler/blade-tabler-icons`](https://github.com/ryangjchandler/blade-tabler-icons) package to the third party list.