### PR TITLE
Seperate icon cache by sets and name

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -95,13 +95,13 @@ final class Factory
      */
     private function contents(string $set, string $name): string
     {
-        if (isset($this->cache[$name])) {
-            return $this->cache[$name];
+        if (isset($this->cache[$set][$name])) {
+            return $this->cache[$set][$name];
         }
 
         if (isset($this->sets[$set])) {
             try {
-                return $this->cache[$name] = $this->getSvgFromPath($name, $this->sets[$set]['path']);
+                return $this->cache[$set][$name] = $this->getSvgFromPath($name, $this->sets[$set]['path']);
             } catch (FileNotFoundException $exception) {
                 //
             }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -91,23 +91,26 @@ HTML;
     /** @test */
     public function icons_are_cached()
     {
-        $options = [
-            'path' => __DIR__ . '/resources/svg',
-            'prefix' => 'icon',
-        ];
-
         $filesystem = Mockery::mock(Filesystem::class);
         $filesystem->shouldReceive('missing')->andReturn(false);
-        $filesystem->shouldReceive('allFiles')->with($options['path'])->andReturn([]);
-        $filesystem->shouldReceive('get')->once()->andReturn('<svg></svg>');
+        $filesystem->shouldReceive('get')->once()->with('/default/svg/camera.svg')->andReturn('<svg></svg>');
+        $filesystem->shouldReceive('get')->once()->with('/heroicon/svg/camera.svg')->andReturn('<svg></svg>');
 
         $factory = new Factory($filesystem);
 
-        $factory->add('default', $options);
+        $factory->add('default', [
+            'path' => '/default/svg',
+            'prefix' => 'default',
+        ]);
+        $factory->add('heroicon', [
+            'path' => '/heroicon/svg',
+            'prefix' => 'heroicon',
+        ]);
 
         $factory->svg('camera');
         $factory->svg('camera');
-        $factory->svg('camera');
+        $factory->svg('heroicon-camera');
+        $factory->svg('heroicon-camera');
     }
 
     /** @test */


### PR DESCRIPTION
Assume we have 3 icon sets and each set has a `bell` icon.

Currently the first used icon will be `cached` only by `name`.
So each icon used after the first one with the same name will show the content from the first one.

This PR caches icons by sets so there are no more name collisions.

Cheers Adrian