### PR TITLE
Allow icon sets to be filtered

### DIFF
--- a/config/blade-icons.php
+++ b/config/blade-icons.php
@@ -71,7 +71,7 @@ return [
     | If a set is not listed below, all icons in that set will be loaded.
     */
 
-    'filter' => [
+    'filters' => [
     //     'default' => [
     //         'icon1',
     //         'icon3'

--- a/config/blade-icons.php
+++ b/config/blade-icons.php
@@ -16,7 +16,7 @@ return [
     'sets' => [
 
         // 'default' => [
-
+        //
         //     /*
         //     |-----------------------------------------------------------------
         //     | Icons Path
@@ -27,9 +27,9 @@ return [
         //     | so there's no need to list every sub-directory.
         //     |
         //     */
-
+        //
         //     'path' => 'resources/svg',
-
+        //
         //     /*
         //     |--------------------------------------------------------------------------
         //     | Default Prefix
@@ -40,9 +40,9 @@ return [
         //     | to every icon name. It's required and needs to be unique.
         //     |
         //     */
-
+        //
         //     'prefix' => 'icon',
-
+        //
         //     /*
         //     |--------------------------------------------------------------------------
         //     | Default Set Class
@@ -52,30 +52,34 @@ return [
         //     | will be applied to all icons by default within this set.
         //     |
         //     */
-
+        //
         //     'class' => '',
-
+        //
         // ],
 
     ],
 
     /*
     |--------------------------------------------------------------------------
-    | Filter Set Icons
+    | Icon Set Filters
     |--------------------------------------------------------------------------
     |
-    | This config option allows you to define a filtered list of
-    | icons that will be loaded out of each speficied. Provide a key name for your icon
-    | set and a combination from the options below.
+    | This config option allows you to define a filtered list of icons that will be
+    | loaded from each specified set, including other packages icon sets.
+    | Provide a key name for your icon set and a combination from the options below.
     |
     | If a set is not listed below, all icons in that set will be loaded.
     */
 
     'filters' => [
-    //     'default' => [
-    //         'icon1',
-    //         'icon3'
-    //     ]
+
+        // 'default' => [
+        //
+        //     'icon1',
+        //     'outline.icon3',
+        //
+        // ]
+
     ],
 
     /*

--- a/config/blade-icons.php
+++ b/config/blade-icons.php
@@ -55,6 +55,18 @@ return [
         //
         //     'class' => '',
         //
+        //     /*
+        //     |--------------------------------------------------------------------------
+        //     | Filter Set Icons
+        //     |--------------------------------------------------------------------------
+        //     |
+        //     | This config option allows you to define a filtered list of
+        //     | icons that will be loaded out of this set
+        //     |
+        //     */
+        //
+        //     'filter' => [],
+        //
         // ],
 
     ],

--- a/config/blade-icons.php
+++ b/config/blade-icons.php
@@ -71,12 +71,12 @@ return [
     | If a set is not listed below, all icons in that set will be loaded.
     */
 
-    // 'filter' => [
+    'filter' => [
     //     'default' => [
     //         'icon1',
     //         'icon3'
     //     ]
-    // ],
+    ],
 
     /*
     |--------------------------------------------------------------------------

--- a/config/blade-icons.php
+++ b/config/blade-icons.php
@@ -16,7 +16,7 @@ return [
     'sets' => [
 
         // 'default' => [
-        //
+
         //     /*
         //     |-----------------------------------------------------------------
         //     | Icons Path
@@ -27,9 +27,9 @@ return [
         //     | so there's no need to list every sub-directory.
         //     |
         //     */
-        //
+
         //     'path' => 'resources/svg',
-        //
+
         //     /*
         //     |--------------------------------------------------------------------------
         //     | Default Prefix
@@ -40,9 +40,9 @@ return [
         //     | to every icon name. It's required and needs to be unique.
         //     |
         //     */
-        //
+
         //     'prefix' => 'icon',
-        //
+
         //     /*
         //     |--------------------------------------------------------------------------
         //     | Default Set Class
@@ -52,24 +52,31 @@ return [
         //     | will be applied to all icons by default within this set.
         //     |
         //     */
-        //
+
         //     'class' => '',
-        //
-        //     /*
-        //     |--------------------------------------------------------------------------
-        //     | Filter Set Icons
-        //     |--------------------------------------------------------------------------
-        //     |
-        //     | This config option allows you to define a filtered list of
-        //     | icons that will be loaded out of this set
-        //     |
-        //     */
-        //
-        //     'filter' => [],
-        //
+
         // ],
 
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Filter Set Icons
+    |--------------------------------------------------------------------------
+    |
+    | This config option allows you to define a filtered list of
+    | icons that will be loaded out of each speficied. Provide a key name for your icon
+    | set and a combination from the options below.
+    |
+    | If a set is not listed below, all icons in that set will be loaded.
+    */
+
+    // 'filter' => [
+    //     'default' => [
+    //         'icon1',
+    //         'icon3'
+    //     ]
+    // ],
 
     /*
     |--------------------------------------------------------------------------

--- a/src/BladeIconsServiceProvider.php
+++ b/src/BladeIconsServiceProvider.php
@@ -36,6 +36,8 @@ final class BladeIconsServiceProvider extends ServiceProvider
 
             $factory = new Factory(new Filesystem(), $config['class'] ?? '');
 
+            $factory->addFilters($config['filters'] ?? []);
+
             foreach ($config['sets'] ?? [] as $set => $options) {
                 $options['path'] = $app->basePath($options['path']);
 

--- a/src/BladeIconsServiceProvider.php
+++ b/src/BladeIconsServiceProvider.php
@@ -36,13 +36,13 @@ final class BladeIconsServiceProvider extends ServiceProvider
 
             $factory = new Factory(new Filesystem(), $config['class'] ?? '');
 
-            $factory->addFilters($config['filters'] ?? []);
-
             foreach ($config['sets'] ?? [] as $set => $options) {
                 $options['path'] = $app->basePath($options['path']);
 
                 $factory->add($set, $options);
             }
+
+            $factory->addFilters($config['filters'] ?? []);
 
             return $factory;
         });

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -77,7 +77,7 @@ final class Factory
     public function registerComponents(): void
     {
         foreach ($this->sets as $set => $options) {
-            foreach ($this->getSetFiles($set) as $file) {
+            foreach ($this->getFiles($set) as $file) {
                 $path = array_filter(explode('/', Str::after($file->getPath(), $options['path'])));
 
                 Blade::component(
@@ -89,7 +89,7 @@ final class Factory
         }
     }
 
-    public function getSetFiles($set): array
+    public function getFiles($set): array
     {
         $options = $this->sets[$set];
 
@@ -97,7 +97,7 @@ final class Factory
 
         if ($filters->count() > 0) {
             return $filters->map(function ($filter) use ($set, $options) {
-                return $this->getSetFile($set, $options, $filter);
+                return $this->getFile($set, $options['path'], $filter);
             })->toArray();
         }
 
@@ -107,16 +107,16 @@ final class Factory
     /**
      * @throws SvgNotFound
      */
-    public function getSetFile($set, $options, $filter): SplFileInfo
+    public function getFile($set, $path, $name): SplFileInfo
     {
         $file = new SplFileInfo(sprintf(
             '%s/%s.svg',
-            rtrim($options['path']),
-            str_replace('.', '/', $filter)
+            rtrim($path),
+            str_replace('.', '/', $name)
         ), '', '');
 
         if (! $file->isFile()) {
-            throw SvgNotFound::missing($set, $filter);
+            throw SvgNotFound::missing($set, $name);
         }
 
         return $file;

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -86,13 +86,9 @@ final class Factory
         $filters = collect($set['filter'] ?? []);
 
         if ($filters->count() > 0) {
-            $files = collect();
-
-            $files = $filters->map(function ($filter) use ($set){
+            return $filters->map(function ($filter) use ($set) {
                 return $this->getFile($set['path'], $filter);
-            });
-
-            return $files->toArray();
+            })->toArray();
         }
 
         return $this->filesystem->allFiles($set['path']);

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -89,15 +89,18 @@ final class Factory
             $files = collect();
 
             foreach ($filters as $filter) {
-                $files->push(new SplFileInfo(sprintf(
-                    '%s/%s.svg',
-                    rtrim($set['path']),
-                    str_replace('.', '/', $filter)
-                ), "", ""));
+                $files->push(
+                    new SplFileInfo(sprintf(
+                        '%s/%s.svg',
+                        rtrim($set['path']),
+                        str_replace('.', '/', $filter)
+                    ), '', '')
+                );
             }
 
             return $files->toArray();
         }
+
         return $this->filesystem->allFiles($set['path']);
     }
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -67,10 +67,6 @@ final class Factory
             throw CannotRegisterIconSet::nonExistingPath($set, $options['path']);
         }
 
-        if (isset($this->filters[$set])) {
-            $options['filters'] = $this->filters[$set];
-        }
-
         $this->sets[$set] = $options;
 
         $this->cache = [];
@@ -97,7 +93,7 @@ final class Factory
     {
         $options = $this->sets[$set];
 
-        $filters = collect($options['filters'] ?? []);
+        $filters = collect($this->filters[$set] ?? []);
 
         if ($filters->count() > 0) {
             return $filters->map(function ($filter) use ($set, $options) {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -68,7 +68,7 @@ final class Factory
         }
 
         if (isset($this->filters[$set])) {
-            $options['filter'] = $this->filters[$set];
+            $options['filters'] = $this->filters[$set];
         }
 
         $this->sets[$set] = $options;
@@ -97,7 +97,7 @@ final class Factory
     {
         $options = $this->sets[$set];
 
-        $filters = collect($options['filter'] ?? []);
+        $filters = collect($options['filters'] ?? []);
 
         if ($filters->count() > 0) {
             return $filters->map(function ($filter) use ($set, $options) {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -88,20 +88,32 @@ final class Factory
         if ($filters->count() > 0) {
             $files = collect();
 
-            foreach ($filters as $filter) {
-                $files->push(
-                    new SplFileInfo(sprintf(
-                        '%s/%s.svg',
-                        rtrim($set['path']),
-                        str_replace('.', '/', $filter)
-                    ), '', '')
-                );
-            }
+            $files = $filters->map(function ($filter) use ($set){
+                return $this->getFile($set['path'], $filter);
+            });
 
             return $files->toArray();
         }
 
         return $this->filesystem->allFiles($set['path']);
+    }
+
+    /**
+     * @throws SvgNotFound
+     */
+    public function getFile($path, $fileName): SplFileInfo
+    {
+        $file = new SplFileInfo(sprintf(
+            '%s/%s.svg',
+            rtrim($path),
+            str_replace('.', '/', $fileName)
+        ), '', '');
+
+        if (! $file->isFile()) {
+            throw SvgNotFound::missing($path, $fileName);
+        }
+
+        return $file;
     }
 
     /**

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -51,51 +51,33 @@ class FactoryTest extends TestCase
     /** @test */
     public function it_can_get_only_filtered_icons_in_a_set()
     {
-        $set = 'default';
-        $options = [
-            'path' => __DIR__ . '/resources/svg',
-            'prefix' => 'icon',
-            'class' => '',
-        ];
+        $factory = $this->prepareSets();
 
-        $factory = new Factory(new Filesystem(), '');
-
-        $factory->addFilters(
-            [$set => [
+        $factory->addFilters([
+            'default' => [
                 'zondicon-flag',
                 'solid.camera'
-            ]]
-        );
+            ]
+        ]);
 
-        $factory->add($set, $options);
-
-        $this->assertCount(2, $factory->getSetFiles($set));
+        $this->assertCount(2, $factory->getSetFiles('default'));
     }
 
     /** @test */
     public function it_throws_an_exception_when_filtered_icon_is_not_found()
     {
-        $set = 'default';
-        $options = [
-            'path' => __DIR__ . '/resources/svg',
-            'prefix' => 'icon',
-            'class' => '',
-        ];
-
-        $factory = new Factory(new Filesystem(), '');
+        $factory = $this->prepareSets();
 
         $factory->addFilters([
-            $set => [
+            'default' => [
                 'money'
             ],
         ]);
 
-        $factory->add($set, $options);
-
         $this->expectException(SvgNotFound::class);
         $this->expectExceptionMessage('Svg by name "money" from set "default" not found.');
 
-        $factory->getSetFiles($set, $options);
+        $factory->getSetFiles('default');
     }
 
     /** @test */

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -31,6 +31,42 @@ class FactoryTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_all_icons_in_a_set()
+    {
+        $set = [
+            'path' => __DIR__ . '/resources/svg',
+            'prefix' => 'icon',
+            'class' => '',
+        ];
+
+        $factory = (new Factory(new Filesystem(), ''))
+            ->add('default', $set);
+
+        $files = $factory->getFiles($set);
+
+        $this->assertCount(4, $files);
+    }
+
+    /** @test */
+    public function it_can_get_only_filtered_icons_in_a_set()
+    {
+        $set = [
+            'path' => __DIR__ . '/resources/svg',
+            'prefix' => 'icon',
+            'class' => '',
+            'filter' => [
+                'zondicon-flag',
+                'solid.camera'
+            ],
+        ];
+
+        $factory = (new Factory(new Filesystem(), ''))
+            ->add('default', $set);
+
+        $this->assertCount(2, $factory->getFiles($set));
+    }
+
+    /** @test */
     public function it_can_retrieve_an_icon()
     {
         $factory = $this->prepareSets();

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -33,16 +33,18 @@ class FactoryTest extends TestCase
     /** @test */
     public function it_can_get_all_icons_in_a_set()
     {
-        $set = [
+        $set = 'default';
+        $options = [
             'path' => __DIR__ . '/resources/svg',
             'prefix' => 'icon',
             'class' => '',
+            'filtered' => [],
         ];
 
         $factory = (new Factory(new Filesystem(), ''))
-            ->add('default', $set);
+            ->add($set, $options);
 
-        $files = $factory->getFiles($set);
+        $files = $factory->getSetFiles($set, $options);
 
         $this->assertCount(4, $files);
     }
@@ -50,7 +52,8 @@ class FactoryTest extends TestCase
     /** @test */
     public function it_can_get_only_filtered_icons_in_a_set()
     {
-        $set = [
+        $set = 'default';
+        $options = [
             'path' => __DIR__ . '/resources/svg',
             'prefix' => 'icon',
             'class' => '',
@@ -61,9 +64,31 @@ class FactoryTest extends TestCase
         ];
 
         $factory = (new Factory(new Filesystem(), ''))
-            ->add('default', $set);
+            ->add($set, $options);
 
-        $this->assertCount(2, $factory->getFiles($set));
+        $this->assertCount(2, $factory->getSetFiles($set, $options));
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_filtered_icon_is_not_found()
+    {
+        $set = 'default';
+        $options = [
+            'path' => __DIR__ . '/resources/svg',
+            'prefix' => 'icon',
+            'class' => '',
+            'filter' => [
+                'money'
+            ],
+        ];
+
+        $factory = (new Factory(new Filesystem(), ''))
+            ->add($set, $options);
+
+        $this->expectException(SvgNotFound::class);
+        $this->expectExceptionMessage('Svg by name "money" from set "default" not found.');
+
+        $factory->getSetFiles($set, $options);
     }
 
     /** @test */

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -38,7 +38,6 @@ class FactoryTest extends TestCase
             'path' => __DIR__ . '/resources/svg',
             'prefix' => 'icon',
             'class' => '',
-            'filtered' => [],
         ];
 
         $factory = (new Factory(new Filesystem(), ''))
@@ -57,16 +56,20 @@ class FactoryTest extends TestCase
             'path' => __DIR__ . '/resources/svg',
             'prefix' => 'icon',
             'class' => '',
-            'filter' => [
-                'zondicon-flag',
-                'solid.camera'
-            ],
         ];
 
-        $factory = (new Factory(new Filesystem(), ''))
-            ->add($set, $options);
+        $factory = new Factory(new Filesystem(), '');
 
-        $this->assertCount(2, $factory->getSetFiles($set, $options));
+        $factory->addFilters(
+            [$set => [
+                'zondicon-flag',
+                'solid.camera'
+            ]]
+        );
+
+        $factory->add($set, $options);
+
+        $this->assertCount(2, $factory->getSetFiles($set));
     }
 
     /** @test */
@@ -77,13 +80,17 @@ class FactoryTest extends TestCase
             'path' => __DIR__ . '/resources/svg',
             'prefix' => 'icon',
             'class' => '',
-            'filter' => [
-                'money'
-            ],
         ];
 
-        $factory = (new Factory(new Filesystem(), ''))
-            ->add($set, $options);
+        $factory = new Factory(new Filesystem(), '');
+
+        $factory->addFilters([
+            $set => [
+                'money'
+            ],
+        ]);
+
+        $factory->add($set, $options);
 
         $this->expectException(SvgNotFound::class);
         $this->expectExceptionMessage('Svg by name "money" from set "default" not found.');

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -43,7 +43,7 @@ class FactoryTest extends TestCase
         $factory = (new Factory(new Filesystem(), ''))
             ->add($set, $options);
 
-        $files = $factory->getSetFiles($set, $options);
+        $files = $factory->getFiles($set, $options);
 
         $this->assertCount(4, $files);
     }
@@ -60,7 +60,7 @@ class FactoryTest extends TestCase
             ]
         ]);
 
-        $this->assertCount(2, $factory->getSetFiles('default'));
+        $this->assertCount(2, $factory->getFiles('default'));
     }
 
     /** @test */
@@ -77,7 +77,7 @@ class FactoryTest extends TestCase
         $this->expectException(SvgNotFound::class);
         $this->expectExceptionMessage('Svg by name "money" from set "default" not found.');
 
-        $factory->getSetFiles('default');
+        $factory->getFiles('default');
     }
 
     /** @test */


### PR DESCRIPTION
Hi @driesvints,

This is reference to issue #71 performance concerns, and implements your second suggestion to manually build a list of icons from a set.

I looked at caching the component names like the Laravel packages.php but decided it was to much to wrap my head around for today, so I thought filtering would be an easier option for now.

It took a bit of testing, as I didn't want to impact any of the existing icon packages, or require any updates/changes to them.

How this works is the user would need to publish the blade-icons.php config file and then add a list of icon names for the set they want to limit in the filters array. This also works using dot syntax for nested icons. Any sets not specified will have all their icons loaded, that way you can just limit specific sets.

Example: The below config filters the [Blade Material Design Icons](https://github.com/renoki-co/blade-mdi) package as it contains over 5,000 icons
```php
'filters' => [
        'blade-mdi' => [
            'menu',
            'home',
            'magnify',
            'chevron-right',
            'plus',
            'calendar-today',
            'calendar-range',
            'menu-down',
            'briefcase-variant',
            'account',
        ],

    ],
```

My test suite normally takes ~30secs but loading up the Blade Material Design Icons package meant I was getting times of ~1min40secs. After applying the above filter I'm back down to about ~30secs again.

I hope this helps. Let me know what you think and whether you think I need to change anything. I haven't updated the README or CHANGELOG yet, I will do so if you are happy with the way I've implmented this.
