### PR TITLE
Add option to disable component registration

### DIFF
--- a/config/blade-icons.php
+++ b/config/blade-icons.php
@@ -71,4 +71,17 @@ return [
 
     'class' => '',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Blade Component Tags
+    |--------------------------------------------------------------------------
+    |
+    | When this option is enabled Blade components will not be registered.
+    | You may enable this when you are not using the "x-" tag syntax
+    | and only want to use the Blade directive or svg helper.
+    |
+    */
+
+    'disable_tags' => false,
+
 ];

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -67,6 +67,10 @@ final class Factory
 
     public function registerComponents(): void
     {
+        if (! $this->shouldRegisterComponents()) {
+            return;
+        }
+
         foreach ($this->sets as $set) {
             foreach ($this->filesystem->allFiles($set['path']) as $file) {
                 $path = array_filter(explode('/', Str::after($file->getPath(), $set['path'])));
@@ -159,5 +163,10 @@ final class Factory
             trim(sprintf('%s %s', $this->defaultClass, $this->sets[$set]['class'] ?? '')),
             $class
         ));
+    }
+
+    private function shouldRegisterComponents(): bool
+    {
+        return ! config('blade-icons.disable_tags', false);
     }
 }

--- a/tests/ComponentsTest.php
+++ b/tests/ComponentsTest.php
@@ -34,7 +34,7 @@ class ComponentsTest extends TestCase
     }
 
     /** @test */
-    public function componenets_are_not_registerd_when_disabled()
+    public function components_are_not_registerd_when_disabled()
     {
         $this->app->config->set('blade-icons.disable_tags', true);
 

--- a/tests/ComponentsTest.php
+++ b/tests/ComponentsTest.php
@@ -34,6 +34,18 @@ class ComponentsTest extends TestCase
     }
 
     /** @test */
+    public function componenets_are_not_registerd_when_disabled()
+    {
+        $this->app->config->set('blade-icons.disable_tags', true);
+
+        $this->prepareSets()->registerComponents();
+
+        $compiled = Blade::getClassComponentAliases();
+
+        $this->assertNotContains(Svg::class, $compiled);
+    }
+
+    /** @test */
     public function it_can_render_an_icon()
     {
         $this->prepareSets();


### PR DESCRIPTION
Related to #71

If you are only using the blade directive with the `@svg` or `svg` helper there is no need to register all the components.

This PR adds a config option to disable the registration of the components.