### PR TITLE
Add caching

### DIFF
--- a/src/BladeIconsServiceProvider.php
+++ b/src/BladeIconsServiceProvider.php
@@ -34,7 +34,7 @@ final class BladeIconsServiceProvider extends ServiceProvider
         $this->app->singleton(Factory::class, function (Application $app) {
             $config = $app->make('config')->get('blade-icons');
 
-            $factory = new Factory(new Filesystem(), $config['class'] ?? '');
+            $factory = new Factory(new Filesystem(), $app->make(Cache::class), $config['class'] ?? '');
 
             foreach ($config['sets'] ?? [] as $set => $options) {
                 $options['path'] = $app->basePath($options['path']);

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -1,0 +1,69 @@
+<?php
+
+
+namespace BladeUI\Icons;
+
+
+use Illuminate\Filesystem\Filesystem;
+
+class Cache
+{
+    /**
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @var string
+     */
+    private $path;
+
+    /** @var array */
+    private $cache = [];
+
+    public function __construct(Filesystem $filesystem)
+    {
+        $this->filesystem = $filesystem;
+        $this->path = base_path('bootstrap/cache/blade-icons.php');
+
+        if ($this->filesystem->exists($this->path)) {
+            $this->cache = require($this->path);
+        }
+    }
+
+    public function get(string $name, array $set)
+    {
+        if (isset($this->cache[$name]) === false) {
+            return $this->updateCache($name, $set);
+        }
+
+        return $this->cache[$name];
+    }
+
+    private function updateCache(string $name, array $set) {
+        $meta = $this->readSetMetaFromFilesystem($set);
+
+        $this->cache[$name] = $meta;
+
+        $this->filesystem->put(
+            $this->path,
+            '<?php return '.var_export($this->cache, true).';'.PHP_EOL
+        );
+
+        return $meta;
+    }
+
+    private function readSetMetaFromFilesystem(array $set) {
+        $meta = [];
+
+        foreach ($this->filesystem->allFiles($set['path']) as $file) {
+            $meta[] = [
+                'extension' => $file->getExtension(),
+                'path' => $file->getPath(),
+                'filename' => $file->getFilename(),
+            ];
+        }
+
+        return $meta;
+    }
+}

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -168,17 +168,17 @@ final class Factory
         ));
     }
 
-    private function registerComponent(array $set, string $extension, string $iconPath, string $filename)
+    private function registerComponent(array $set, string $extension, string $path, string $filename)
     {
         if ($extension !== 'svg') {
             return;
         }
 
-        $iconPath = array_filter(explode('/', Str::after($iconPath, $set['path'])));
+        $path = array_filter(explode('/', Str::after($path, $set['path'])));
 
         Blade::component(
             SvgComponent::class,
-            implode('.', array_filter($iconPath + [$filename])),
+            implode('.', array_filter($path + [$filename])),
             $set['prefix'],
         );
     }


### PR DESCRIPTION
This PR adds basic file caching for file metadata information by writing said data to a php file in `bootstrap/cache`, like Laravel's built-in config caching. Should help resolve #71

If the provided approach is acceptable I will add tests to this PR.