### PR TITLE
Implement icon fallback support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This changelog follows [the Keep a Changelog standard](https://keepachangelog.co
 
 ## [Unreleased](https://github.com/blade-ui-kit/blade-icons/compare/0.5.1...main)
 
+### Added
+- Fallback support on set and global level. ([#109](https://github.com/blade-ui-kit/blade-icons/pull/109))
+
 
 ## [0.5.1 (2020-11-05)](https://github.com/blade-ui-kit/blade-icons/compare/0.5.0...0.5.1)
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,28 @@ If you don't want any classes to be applied by default then leave this as an emp
 
 The sequence in which classes get applied is `<global classes> <set classes> <explicit classes>`. You can always override this by passing an explicit class with your attributes. Component classes cannot be overriden.
 
+### Fallbacks
+
+You can optionally define a fallback icon which will be applied when the requested icon does not exist.
+This can be configured by setting the `fallback` setting in your `blade-icons.php` config file and can be configured 
+o both set and global level:
+
+```php
+<?php
+
+return [
+    'fallback' => 'default-icon-name',
+    
+    'sets' => [
+        'default' => [
+            'fallback' => 'set-fallback-icon-name',
+        ],
+    ],
+];
+```
+
+If this is not configured, or the fallback icon also does not exist, an `Exception` will be thrown.
+
 ## Usage
 
 There are several ways of inserting icons into your Blade templates. We personally recommend using Blade components, but you can also make use of a Blade directive if you wish.

--- a/config/blade-icons.php
+++ b/config/blade-icons.php
@@ -55,6 +55,18 @@ return [
         //
         //     'class' => '',
         //
+        //     /*
+        //     |--------------------------------------------------------------------------
+        //     | Default Set Fallback
+        //     |--------------------------------------------------------------------------
+        //     |
+        //     | This config option allows you to define the icon name that is
+        //     | used as a fallback within this set.
+        //     |
+        //     */
+        //
+        //     'fallback' => '',
+        //
         // ],
 
     ],
@@ -70,5 +82,17 @@ return [
     */
 
     'class' => '',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Fallback
+    |--------------------------------------------------------------------------
+    |
+    | This config option allows you to define the icon name that is
+    | used as a fallback when a set fallback is missing or invalid.
+    |
+    */
+
+    'fallback' => '',
 
 ];

--- a/src/BladeIconsServiceProvider.php
+++ b/src/BladeIconsServiceProvider.php
@@ -34,7 +34,7 @@ final class BladeIconsServiceProvider extends ServiceProvider
         $this->app->singleton(Factory::class, function (Application $app) {
             $config = $app->make('config')->get('blade-icons');
 
-            $factory = new Factory(new Filesystem(), $config['class'] ?? '');
+            $factory = new Factory(new Filesystem(), $config['class'] ?? '', $config['fallback'] ?? '');
 
             foreach ($config['sets'] ?? [] as $set => $options) {
                 $options['path'] = $app->basePath($options['path']);

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -200,5 +200,4 @@ final class Factory
             str_replace('.', '/', $name),
         );
     }
-
 }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -92,6 +92,7 @@ class FactoryTest extends TestCase
     public function icons_are_cached()
     {
         $filesystem = Mockery::mock(Filesystem::class);
+        $filesystem->shouldReceive('exists')->andReturn(true);
         $filesystem->shouldReceive('missing')->andReturn(false);
         $filesystem->shouldReceive('get')
             ->once()
@@ -271,6 +272,39 @@ class FactoryTest extends TestCase
         ]);
 
         $this->assertSame(__DIR__.'/resources/svg', $factory->all()['default']['path']);
+    }
+
+    /** @test */
+    public function it_uses_the_set_fallback_when_configured(): void
+    {
+        $fallbackSvg = 'camera';
+        $factory = $this->prepareSets('', [], '', ['default' => $fallbackSvg]);
+
+        $icon = $factory->svg('foobar-i-do-not-exist');
+
+        $this->assertSame($fallbackSvg, $icon->name());
+    }
+
+    /** @test */
+    public function it_uses_the_default_fallback_when_configured(): void
+    {
+        $fallbackSvg = 'camera';
+        $factory = $this->prepareSets('', [], $fallbackSvg, []);
+
+        $icon = $factory->svg('some-icon-that-does-not-exist');
+
+        $this->assertSame($fallbackSvg, $icon->name());
+    }
+
+    /** @test */
+    public function it_uses_the_default_fallback_when_set_fallback_does_not_exist(): void
+    {
+        $expectedSvg = 'camera';
+        $factory = $this->prepareSets('', [],$expectedSvg, ['default' => 'fallback-that-does-not-exist']);
+
+        $icon = $factory->svg('some-icon-that-does-not-exist');
+
+        $this->assertSame($expectedSvg, $icon->name());
     }
 
     protected function getPackageProviders($app): array

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -300,7 +300,7 @@ class FactoryTest extends TestCase
     public function it_uses_the_default_fallback_when_set_fallback_does_not_exist(): void
     {
         $expectedSvg = 'camera';
-        $factory = $this->prepareSets('', [],$expectedSvg, ['default' => 'fallback-that-does-not-exist']);
+        $factory = $this->prepareSets('', [], $expectedSvg, ['default' => 'fallback-that-does-not-exist']);
 
         $icon = $factory->svg('some-icon-that-does-not-exist');
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,18 +11,20 @@ use Orchestra\Testbench\TestCase as OrchestraTestCase;
 
 abstract class TestCase extends OrchestraTestCase
 {
-    protected function prepareSets(string $defaultClass = '', array $setClasses = []): Factory
+    protected function prepareSets(string $defaultClass = '', array $setClasses = [], string $defaultFallback = '', array $fallbacks = []): Factory
     {
-        $factory = (new Factory(new Filesystem(), $defaultClass))
+        $factory = (new Factory(new Filesystem(), $defaultClass, $defaultFallback))
             ->add('default', [
                 'path' => __DIR__.'/resources/svg',
                 'prefix' => 'icon',
                 'class' => $setClasses['default'] ?? '',
+                'fallback' => $fallbacks['default'] ?? '',
             ])
             ->add('zondicons', [
                 'path' => __DIR__.'/resources/zondicons',
                 'prefix' => 'zondicon',
                 'class' => $setClasses['zondicons'] ?? '',
+                'fallback' => $fallbacks['zondicons'] ?? '',
             ]);
 
         return $this->app->instance(Factory::class, $factory);


### PR DESCRIPTION
<!--
Please only send a pull request to the latest release branch.

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; etc.

If applicable, also send a PR to the docs for the new change you're submitting.
-->
I added support for configuring a fallback file globally and per set. I also added a few tests and made sure existing tests still work. Since the options are optional this should be backwards compatible.

The only caveat is that we can't implement this for Blade components. The reasoning behind this is that these are registered by name and referencing nonexistent icons would throw a component not found.

This should be useful to users. The only thing I can think of that could also be implemented is fallbacks passed through via array. If you want I can implement that? (#48)
