### PR TITLE
Default Icon class

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,15 @@ Looking for a specific icon? Try our icon search: https://blade-ui-kit.com/blade
 - [Installation](#installation)
 - [Updating](#updating)
 - [Configuration](#configuration)
-    - [Defining Sets](#defining-sets)
-    - [Icon Paths](#icon-paths)
-    - [Prefixing Icons](#prefixing-icons)
-    - [Default Classes](#default-classes)
+  - [Defining Sets](#defining-sets)
+  - [Icon Paths](#icon-paths)
+  - [Prefixing Icons](#prefixing-icons)
+  - [Default Classes](#default-classes)
 - [Usage](#usage)
-    - [Components](#components)
-    - [Directive](#directive)
-    - [Helper](#helper)
+  - [Components](#components)
+    - [Default Component](#default-component)
+  - [Directive](#directive)
+  - [Helper](#helper)
 - [Building Packages](#building-packages)
 - [Changelog](#changelog)
 - [Maintainers](#maintainers)
@@ -173,7 +174,7 @@ return [
 
 If you don't want any classes to be applied by default then leave this as an empty string. Additionally, the same option is available in sets so you can set default classes on every set.
 
-The sequence in which classes get applied is `<global classes> <set classes> <explicit classes>`. You can always override this by passing an explicit class with your attributes. Component classes cannot be overriden.
+The sequence in which classes get applied is `<global classes> <set classes> <explicit classes>`. You can always override this by passing an explicit class with your attributes. Component classes cannot be overridden.
 
 ## Usage
 
@@ -206,6 +207,44 @@ Or any other attributes for that matter:
 ```
 
 > Note that with Blade components, using a prefix is always required, even when referencing icons from the default set.
+
+#### Default Component
+
+If you don't want to use the component syntax from above you can also make use of the default `Icon` component that ships with Blade Icons. Simply pass the icon name through the `$name` attribute:
+
+```blade
+<x-icon name="camera"/>
+```
+
+If you want to use a different name for this component instead you can customize the `components.default` option in your `blade-icons.php` config file:
+
+```php
+<?php
+
+return [
+    'components' => [
+        'default' => 'svg',
+    ],
+];
+```
+
+Then reference the default icon as follow:
+
+```blade
+<x-svg name="camera"/>
+```
+
+You can also completely disable this default component if you want by setting its name to `null`:
+
+```php
+<?php
+
+return [
+    'components' => [
+        'default' => null,
+    ],
+];
+```
 
 ### Directive
 

--- a/config/blade-icons.php
+++ b/config/blade-icons.php
@@ -93,7 +93,7 @@ return [
         |
         */
 
-        'default' => '',
+        'default' => 'icon',
 
     ],
 

--- a/config/blade-icons.php
+++ b/config/blade-icons.php
@@ -31,9 +31,9 @@ return [
         //     'path' => 'resources/svg',
         //
         //     /*
-        //     |--------------------------------------------------------------------------
+        //     |-----------------------------------------------------------------
         //     | Default Prefix
-        //     |--------------------------------------------------------------------------
+        //     |-----------------------------------------------------------------
         //     |
         //     | This config option allows you to define a default prefix for
         //     | your icons. The dash separator will be applied automatically
@@ -44,12 +44,12 @@ return [
         //     'prefix' => 'icon',
         //
         //     /*
-        //     |--------------------------------------------------------------------------
+        //     |-----------------------------------------------------------------
         //     | Default Set Class
-        //     |--------------------------------------------------------------------------
+        //     |-----------------------------------------------------------------
         //     |
         //     | This config option allows you to define some classes which
-        //     | will be applied to all icons by default within this set.
+        //     | will be applied by default to all icons within this set.
         //     |
         //     */
         //
@@ -65,10 +65,36 @@ return [
     |--------------------------------------------------------------------------
     |
     | This config option allows you to define some classes which
-    | will be applied to all icons by default.
+    | will be applied by default to all icons.
     |
     */
 
     'class' => '',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Components
+    |--------------------------------------------------------------------------
+    |
+    | These config options allow you to define some
+    | settings related to Blade Components.
+    |
+    */
+
+    'components' => [
+
+        /*
+        |----------------------------------------------------------------------
+        | Default Icon Name
+        |----------------------------------------------------------------------
+        |
+        | This config option allows you to define the name
+        | for the default Icon class component.
+        |
+        */
+
+        'default' => '',
+
+    ],
 
 ];

--- a/src/BladeIconsServiceProvider.php
+++ b/src/BladeIconsServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BladeUI\Icons;
 
+use BladeUI\Icons\Components\Icon;
 use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Application;
@@ -21,6 +22,7 @@ final class BladeIconsServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->bootDirectives();
+        $this->bootIconComponent();
         $this->bootPublishing();
     }
 
@@ -48,6 +50,13 @@ final class BladeIconsServiceProvider extends ServiceProvider
         $this->callAfterResolving(ViewFactory::class, function ($view, Application $app) {
             $app->make(Factory::class)->registerComponents();
         });
+    }
+
+    private function bootIconComponent(): void
+    {
+        if ($name = config('blade-icons.components.default')) {
+            Blade::component($name, Icon::class);
+        }
     }
 
     private function bootDirectives(): void

--- a/src/Components/Icon.php
+++ b/src/Components/Icon.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BladeUI\Icons\Components;
+
+use Illuminate\View\Component;
+
+final class Icon extends Component
+{
+    /** @var string */
+    public $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function render()
+    {
+        return function (array $data) {
+            $attributes = $data['attributes']->getIterator()->getArrayCopy();
+
+            $class = $attributes['class'] ?? '';
+
+            unset($attributes['class']);
+
+            return svg($this->name, $class, $attributes)->toHtml();
+        };
+    }
+}

--- a/tests/ComponentsTest.php
+++ b/tests/ComponentsTest.php
@@ -129,6 +129,37 @@ class ComponentsTest extends TestCase
         $this->assertSame($expected, $compiled);
     }
 
+    /** @test */
+    public function it_can_render_an_icon_with_the_icon_component()
+    {
+        $this->prepareSets();
+
+        $compiled = $this->renderView('icon-component');
+
+        $expected = <<<'HTML'
+            <svg data-foo="1" class="icon icon-lg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z"/>
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 13a3 3 0 11-6 0 3 3 0 016 0z"/>
+            </svg>
+            HTML;
+
+        $this->assertSame($expected, $compiled);
+    }
+
+    /** @test */
+    public function it_can_render_an_icon_from_a_specific_set_with_the_icon_component()
+    {
+        $this->prepareSets();
+
+        $compiled = $this->renderView('icon-component-from-set');
+
+        $expected = <<<'HTML'
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M7.667 12H2v8H0V0h12l.333 2H20l-3 6 3 6H8l-.333-2z"/></svg>
+            HTML;
+
+        $this->assertSame($expected, $compiled);
+    }
+
     private function renderView(string $view): string
     {
         return trim(View::file(__DIR__."/resources/views/{$view}.blade.php")->render());

--- a/tests/resources/views/icon-component-from-set.blade.php
+++ b/tests/resources/views/icon-component-from-set.blade.php
@@ -1,0 +1,1 @@
+<x-icon name="zondicon-flag"/>

--- a/tests/resources/views/icon-component.blade.php
+++ b/tests/resources/views/icon-component.blade.php
@@ -1,0 +1,1 @@
+<x-icon name="camera" class="icon icon-lg" data-foo/>


### PR DESCRIPTION
Allows for the following syntax:

```blade
<x-icon name="camera"/>
```

More information on usage added to the readme.

Closes https://github.com/blade-ui-kit/blade-icons/issues/75