### PR TITLE
Implement icon caching

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -2,3 +2,6 @@ preset: laravel
 enabled:
   - heredoc_indentation
   - trailing_comma_in_multiline_call
+finder:
+  exclude:
+    - "tests/fixtures"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Looking for a specific icon? Try our icon search: https://blade-ui-kit.com/blade
 - [Requirements](#requirements)
 - [Installation](#installation)
 - [Updating](#updating)
+- [Caching](#caching)
 - [Configuration](#configuration)
   - [Defining Sets](#defining-sets)
   - [Icon Paths](#icon-paths)
@@ -103,6 +104,26 @@ php artisan vendor:publish --tag=blade-icons
 ## Updating
 
 Please refer to [`the upgrade guide`](UPGRADE.md) when updating the library.
+
+## Caching
+
+When working with Blade Icons, and third party icons in particularly, you'll often be working with large icon sets. This can slow down your app tremendously, especially when making use of [Blade components](#components). To solve this issue, Blade Icons ships with caching support. To enable icon caching you can run the following command:
+
+```blade
+php artisan icons:cache
+```
+
+This will create a `blade-icons.php` file in `bootstrap/cache` similar to the `packages.php` cached file. It'll contain a manifest of all known sets and its icons with their location on their specific disk. 
+
+Caching icons means you won't be able to add extra icons, change paths for icon sets or install/remove icon packages. To do so make sure you first clear the icons cache and cache after you've made these changes:
+
+```bash
+php artisan icons:clear
+```
+
+It's a good idea to add the `icons:cache` command as part of your deployment pipeline and always cache icons in production. 
+
+Alternatively, you may choose to [disable Blade components](#disabling-components) entirely.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ public function register(): void
 {
     $this->callAfterResolving(Factory::class, function (Factory $factory) {
         $factory->add('heroicons', [
-            'path' => __DIR__ . '/../resources/svg',
+            'path' => __DIR__.'/../resources/svg',
             'prefix' => 'heroicon',
         ]);
     });

--- a/src/BladeIconsServiceProvider.php
+++ b/src/BladeIconsServiceProvider.php
@@ -72,7 +72,7 @@ final class BladeIconsServiceProvider extends ServiceProvider
             return new IconsManifest(
                 new Filesystem(),
                 $this->manifestPath(),
-                $app->make(FilesystemFactory::class)
+                $app->make(FilesystemFactory::class),
             );
         });
     }

--- a/src/BladeIconsServiceProvider.php
+++ b/src/BladeIconsServiceProvider.php
@@ -77,7 +77,7 @@ final class BladeIconsServiceProvider extends ServiceProvider
             return new IconsManifest(
                 new Filesystem(),
                 $this->getCachedIconsPath(),
-                $app->make(Factory::class)->all()
+                $app->make(Factory::class)->all(),
             );
         });
     }

--- a/src/BladeIconsServiceProvider.php
+++ b/src/BladeIconsServiceProvider.php
@@ -17,13 +17,13 @@ final class BladeIconsServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->registerConfig();
-        $this->registerCommands();
         $this->registerFactory();
         $this->registerManifest();
     }
 
     public function boot(): void
     {
+        $this->bootCommands();
         $this->bootDirectives();
         $this->bootIconComponent();
         $this->bootPublishing();
@@ -32,16 +32,6 @@ final class BladeIconsServiceProvider extends ServiceProvider
     private function registerConfig(): void
     {
         $this->mergeConfigFrom(__DIR__.'/../config/blade-icons.php', 'blade-icons');
-    }
-
-    private function registerCommands(): void
-    {
-        if ($this->app->runningInConsole()) {
-            $this->commands([
-                Console\CacheCommand::class,
-                Console\ClearCommand::class,
-            ]);
-        }
     }
 
     private function registerFactory(): void
@@ -82,10 +72,18 @@ final class BladeIconsServiceProvider extends ServiceProvider
         });
     }
 
-    private function bootIconComponent(): void
+    private function getCachedIconsPath(): string
     {
-        if ($name = config('blade-icons.components.default')) {
-            Blade::component($name, Icon::class);
+        return $this->app->bootstrapPath('cache/blade-icons.php');
+    }
+
+    private function bootCommands(): void
+    {
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                Console\CacheCommand::class,
+                Console\ClearCommand::class,
+            ]);
         }
     }
 
@@ -96,6 +94,13 @@ final class BladeIconsServiceProvider extends ServiceProvider
         });
     }
 
+    private function bootIconComponent(): void
+    {
+        if ($name = config('blade-icons.components.default')) {
+            Blade::component($name, Icon::class);
+        }
+    }
+
     private function bootPublishing(): void
     {
         if ($this->app->runningInConsole()) {
@@ -103,10 +108,5 @@ final class BladeIconsServiceProvider extends ServiceProvider
                 __DIR__.'/../config/blade-icons.php' => $this->app->configPath('blade-icons.php'),
             ], 'blade-icons');
         }
-    }
-
-    private function getCachedIconsPath(): string
-    {
-        return $this->app->bootstrapPath('cache/blade-icons.php');
     }
 }

--- a/src/BladeIconsServiceProvider.php
+++ b/src/BladeIconsServiceProvider.php
@@ -39,7 +39,12 @@ final class BladeIconsServiceProvider extends ServiceProvider
         $this->app->singleton(Factory::class, function (Application $app) {
             $config = $app->make('config')->get('blade-icons', []);
 
-            $factory = new Factory(new Filesystem(), $app->make(FilesystemFactory::class), $config);
+            $factory = new Factory(
+                new Filesystem(),
+                $app->make(IconsManifest::class),
+                $app->make(FilesystemFactory::class),
+                $config,
+            );
 
             foreach ($config['sets'] ?? [] as $set => $options) {
                 if (! isset($options['disk'])) {
@@ -66,13 +71,13 @@ final class BladeIconsServiceProvider extends ServiceProvider
         $this->app->singleton(IconsManifest::class, function (Application $app) {
             return new IconsManifest(
                 new Filesystem(),
-                $this->getCachedIconsPath(),
-                $app->make(Factory::class)->all(),
+                $this->manifestPath(),
+                $app->make(FilesystemFactory::class)
             );
         });
     }
 
-    private function getCachedIconsPath(): string
+    private function manifestPath(): string
     {
         return $this->app->bootstrapPath('cache/blade-icons.php');
     }

--- a/src/Console/CacheCommand.php
+++ b/src/Console/CacheCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BladeUI\Icons\Console;
 
+use BladeUI\Icons\Factory;
 use BladeUI\Icons\IconsManifest;
 use Illuminate\Console\Command;
 
@@ -23,9 +24,9 @@ final class CacheCommand extends Command
      */
     protected $description = 'Discover icon sets and generate a manifest file';
 
-    public function handle(IconsManifest $manifest): int
+    public function handle(Factory $factory, IconsManifest $manifest): int
     {
-        $manifest->write();
+        $manifest->write($factory->all());
 
         $this->info('Blade icons manifest file generated successfully!');
 

--- a/src/Console/CacheCommand.php
+++ b/src/Console/CacheCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BladeUI\Icons\Console;
+
+use BladeUI\Icons\IconsManifest;
+use Illuminate\Console\Command;
+
+final class CacheCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'icons:cache';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Discover icon sets and generate a manifest file';
+
+    public function handle(IconsManifest $manifest): int
+    {
+        $manifest->write();
+
+        $this->info('Blade icons manifest file generated successfully!');
+
+        return 0;
+    }
+}

--- a/src/Console/ClearCommand.php
+++ b/src/Console/ClearCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BladeUI\Icons\Console;
+
+use BladeUI\Icons\IconsManifest;
+use Illuminate\Console\Command;
+
+final class ClearCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'icons:clear';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Remove the blade icons manifest file';
+
+    public function handle(IconsManifest $manifest): int
+    {
+        $manifest->delete();
+
+        $this->info('Blade icons manifest file cleared!');
+
+        return 0;
+    }
+}

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -188,6 +188,11 @@ final class Factory
             str_replace('.', '/', $name),
         )));
 
+        return $this->cleanSvgContents($contents);
+    }
+
+    private function cleanSvgContents(string $contents): string
+    {
         return trim(preg_replace('/^(<\?xml.+?\?>)/', '', $contents));
     }
 

--- a/src/IconsManifest.php
+++ b/src/IconsManifest.php
@@ -84,7 +84,7 @@ final class IconsManifest
 
         $this->filesystem->replace(
             $this->manifestPath,
-            '<?php return '.var_export($this->build(), true).';'
+            '<?php return '.var_export($this->build(), true).';',
         );
     }
 }

--- a/src/IconsManifest.php
+++ b/src/IconsManifest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BladeUI\Icons;
+
+use Exception;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
+use Symfony\Component\Finder\SplFileInfo;
+
+final class IconsManifest
+{
+    /** @var Filesystem */
+    private $filesystem;
+
+    /** @var array */
+    private $manifest;
+
+    /** @var string */
+    private $manifestPath;
+
+    /** @var array */
+    private $sets;
+
+    public function __construct(Filesystem $filesystem, string $manifestPath, array $sets)
+    {
+        $this->filesystem = $filesystem;
+        $this->manifestPath = $manifestPath;
+        $this->sets = $sets;
+    }
+
+    private function build(): array
+    {
+        $compiled = [];
+
+        foreach ($this->sets as $name => $set) {
+            foreach ($set['paths'] as $path) {
+                foreach ($this->filesystem->allFiles($path) as $file) {
+                    $set['icons'][] = $this->format($file, $path);
+                }
+            }
+
+            $compiled[$name] = $set;
+        }
+
+        return $compiled;
+    }
+
+    public function delete(): bool
+    {
+        return $this->filesystem->delete($this->manifestPath);
+    }
+
+    private function format(SplFileInfo $file, string $path): string
+    {
+        return (string) Str::of($file->getPathName())
+            ->after($path.'/')
+            ->replace('/', '.')
+            ->basename('.'.$file->getExtension());
+    }
+
+    public function getManifest(): array
+    {
+        if (! is_null($this->manifest)) {
+            return $this->manifest;
+        }
+
+        if (! $this->filesystem->exists($this->manifestPath)) {
+            return $this->manifest = $this->build();
+        }
+
+        return $this->manifest = $this->filesystem->getRequire($this->manifestPath);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function write(): void
+    {
+        if (! is_writable($dirname = dirname($this->manifestPath))) {
+            throw new Exception("The {$dirname} directory must be present and writable.");
+        }
+
+        $this->filesystem->replace(
+            $this->manifestPath,
+            '<?php return '.var_export($this->build(), true).';'
+        );
+    }
+}

--- a/src/IconsManifest.php
+++ b/src/IconsManifest.php
@@ -35,13 +35,23 @@ final class IconsManifest
         $compiled = [];
 
         foreach ($this->sets as $name => $set) {
+            $icons = [];
+
             foreach ($set['paths'] as $path) {
+                $icons[$path] = [];
+
                 foreach ($this->filesystem->allFiles($path) as $file) {
-                    $set['icons'][] = $this->format($file, $path);
+                    if ($file->getExtension() !== 'svg') {
+                        continue;
+                    }
+
+                    $icons[$path][] = $this->format($file, $path);
                 }
+
+                $icons[$path] = array_unique($icons[$path]);
             }
 
-            $compiled[$name] = $set;
+            $compiled[$name] = array_filter($icons);
         }
 
         return $compiled;

--- a/tests/CachingTest.php
+++ b/tests/CachingTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+class CachingTest extends TestCase
+{
+    /** @test */
+    public function it_can_create_a_cache_file()
+    {
+        $this->artisan('icons:cache')
+            ->expectsOutput('Blade icons manifest file generated successfully!')
+            ->assertExitCode(0);
+    }
+
+    /** @test */
+    public function it_can_clear_the_cache()
+    {
+        $this->artisan('icons:clear')
+            ->expectsOutput('Blade icons manifest file cleared!')
+            ->assertExitCode(0);
+    }
+}

--- a/tests/ComponentsTest.php
+++ b/tests/ComponentsTest.php
@@ -6,7 +6,6 @@ namespace Tests;
 
 use BladeUI\Icons\Components\Svg;
 use Illuminate\Support\Facades\Blade;
-use Illuminate\View\ViewException;
 use InvalidArgumentException;
 
 class ComponentsTest extends TestCase

--- a/tests/ComponentsTest.php
+++ b/tests/ComponentsTest.php
@@ -6,6 +6,8 @@ namespace Tests;
 
 use BladeUI\Icons\Components\Svg;
 use Illuminate\Support\Facades\Blade;
+use Illuminate\View\ViewException;
+use InvalidArgumentException;
 
 class ComponentsTest extends TestCase
 {
@@ -266,5 +268,16 @@ class ComponentsTest extends TestCase
             HTML;
 
         $view->assertSee($expected, false);
+    }
+
+    /** @test */
+    public function it_files_without_an_svg_extension_are_not_registered()
+    {
+        $this->prepareSets();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to locate a class or view for component [icon-invalid-extension].');
+
+        $this->blade('<x-icon-invalid-extension/>');
     }
 }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -6,6 +6,7 @@ namespace Tests;
 
 use BladeUI\Icons\Exceptions\SvgNotFound;
 use BladeUI\Icons\Factory;
+use BladeUI\Icons\IconsManifest;
 use BladeUI\Icons\Svg;
 use Illuminate\Filesystem\Filesystem;
 use Mockery;
@@ -101,7 +102,7 @@ class FactoryTest extends TestCase
             ->with('/heroicon/svg/camera.svg')
             ->andReturn($heroicon = '<svg>Bar</svg>');
 
-        $factory = new Factory($filesystem);
+        $factory = new Factory($filesystem, $this->app->make(IconsManifest::class));
 
         $factory->add('default', [
             'path' => '/default/svg',
@@ -121,14 +122,18 @@ class FactoryTest extends TestCase
     /** @test */
     public function default_icon_set_is_optional()
     {
-        $factory = (new Factory(new Filesystem(), null, ['class' => 'icon icon-default']))
-            ->add('zondicons', [
-                'path' => __DIR__.'/resources/zondicons',
-                'prefix' => 'zondicon',
-                'class' => 'zondicon-class',
-            ]);
+        $factory = new Factory(
+            new Filesystem(),
+            $this->app->make(IconsManifest::class),
+            null,
+            ['class' => 'icon icon-default']
+        );
 
-        $factory = $this->app->instance(Factory::class, $factory);
+        $factory->add('zondicons', [
+            'path' => __DIR__.'/resources/zondicons',
+            'prefix' => 'zondicon',
+            'class' => 'zondicon-class',
+        ]);
 
         $icon = $factory->svg('zondicon-flag');
 
@@ -138,14 +143,18 @@ class FactoryTest extends TestCase
     /** @test */
     public function icon_not_found_without_default_set_throws_proper_exception()
     {
-        $factory = (new Factory(new Filesystem(), null, ['class' => 'icon icon-default']))
-            ->add('zondicons', [
-                'path' => __DIR__.'/resources/zondicons',
-                'prefix' => 'zondicon',
-                'class' => 'zondicon-class',
-            ]);
+        $factory = new Factory(
+            new Filesystem(),
+            $this->app->make(IconsManifest::class),
+            null,
+            ['class' => 'icon icon-default']
+        );
 
-        $factory = $this->app->instance(Factory::class, $factory);
+        $factory->add('zondicons', [
+            'path' => __DIR__.'/resources/zondicons',
+            'prefix' => 'zondicon',
+            'class' => 'zondicon-class',
+        ]);
 
         $this->expectExceptionObject(new SvgNotFound(
             'Svg by name "foo" from set "zondicons" not found.',
@@ -238,7 +247,7 @@ class FactoryTest extends TestCase
     }
 
     /** @test */
-    public function it_excludes_files_without_an_svg_extension()
+    public function it_throws_an_exception_for_files_without_an_svg_extension()
     {
         $factory = $this->prepareSets();
 

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -126,7 +126,7 @@ class FactoryTest extends TestCase
             new Filesystem(),
             $this->app->make(IconsManifest::class),
             null,
-            ['class' => 'icon icon-default']
+            ['class' => 'icon icon-default'],
         );
 
         $factory->add('zondicons', [
@@ -147,7 +147,7 @@ class FactoryTest extends TestCase
             new Filesystem(),
             $this->app->make(IconsManifest::class),
             null,
-            ['class' => 'icon icon-default']
+            ['class' => 'icon icon-default'],
         );
 
         $factory->add('zondicons', [

--- a/tests/FilesystemDiskTest.php
+++ b/tests/FilesystemDiskTest.php
@@ -36,6 +36,25 @@ class FilesystemDiskTest extends TestCase
         $this->assertSame('flag', $icon->name());
     }
 
+    /** @test */
+    public function it_can_render_an_icon_component()
+    {
+        $this->prepareSets([], ['default' => [
+            'disk' => 'external-disk',
+            'path' => '/',
+        ]]);
+
+        $view = $this->blade('<x-icon-cake/>');
+
+        $expected = <<<'HTML'
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 15.546c-.523 0-1.046.151-1.5.454a2.704 2.704 0 01-3 0 2.704 2.704 0 00-3 0 2.704 2.704 0 01-3 0 2.704 2.704 0 00-3 0 2.704 2.704 0 01-3 0 2.701 2.701 0 00-1.5-.454M9 6v2m3-2v2m3-2v2M9 3h.01M12 3h.01M15 3h.01M21 21v-7a2 2 0 00-2-2H5a2 2 0 00-2 2v7h18zm-3-9v-2a2 2 0 00-2-2H8a2 2 0 00-2 2v2h12z" />
+            </svg>
+            HTML;
+
+        $view->assertSee($expected, false);
+    }
+
     protected function getEnvironmentSetUp($app)
     {
         $app['config']->set('filesystems.disks.external-disk', [

--- a/tests/IconsManifestTest.php
+++ b/tests/IconsManifestTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use BladeUI\Icons\IconsManifest;
+use Exception;
+use Illuminate\Filesystem\Filesystem;
+
+class IconsManifestTest extends TestCase
+{
+    /** @var string */
+    private $manifestPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->manifestPath = __DIR__.'/fixtures/blade-icons.php';
+        @unlink($this->manifestPath);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        @unlink($this->manifestPath);
+    }
+
+    private function expectedManifest(): string
+    {
+        return trim(str_replace(
+            '{{ dir }}',
+            __DIR__,
+            file_get_contents(__DIR__.'/fixtures/generated-manifest.php')
+        ));
+    }
+
+    /** @test */
+    public function it_can_write_the_manifest_file()
+    {
+        $factory = $this->prepareSets();
+        $manifest = new IconsManifest(new Filesystem(), $this->manifestPath, $factory->all());
+        $manifest->write();
+
+        $this->assertTrue(file_exists($this->manifestPath));
+        $this->assertSame($this->expectedManifest(), file_get_contents($this->manifestPath));
+    }
+
+    /** @test */
+    public function it_can_delete_the_manifest_file()
+    {
+        $manifest = new IconsManifest(new Filesystem(), $this->manifestPath, []);
+        $manifest->write();
+
+        $this->assertTrue(file_exists($this->manifestPath));
+        $this->assertTrue($manifest->delete());
+        $this->assertFalse(file_exists($this->manifestPath));
+    }
+
+    /** @test */
+    public function it_throws_an_exceptiion_when_the_manifest_path_is_not_present_or_writable()
+    {
+        $manifest = new IconsManifest(new Filesystem(), '/foo/bar.php', []);
+
+        try {
+            $manifest->write();
+        } catch (Exception $e) {
+            $this->assertSame('The /foo directory must be present and writable.', $e->getMessage());
+
+            return;
+        }
+
+        $this->fail('Trying to write to an unpresent or unwritable directory succeeded.');
+    }
+
+    /** @test */
+    public function it_can_get_the_manifest()
+    {
+        $manifest = new IconsManifest(new Filesystem(), $this->manifestPath, []);
+
+        $this->assertSame([], $manifest->getManifest());
+    }
+}

--- a/tests/IconsManifestTest.php
+++ b/tests/IconsManifestTest.php
@@ -40,9 +40,8 @@ class IconsManifestTest extends TestCase
     /** @test */
     public function it_can_write_the_manifest_file()
     {
-        $factory = $this->prepareSets();
-        $manifest = new IconsManifest(new Filesystem(), $this->manifestPath, $factory->all());
-        $manifest->write();
+        $manifest = new IconsManifest(new Filesystem(), $this->manifestPath);
+        $manifest->write($this->prepareSets()->all());
 
         $this->assertTrue(file_exists($this->manifestPath));
         $this->assertSame(
@@ -54,8 +53,8 @@ class IconsManifestTest extends TestCase
     /** @test */
     public function it_can_delete_the_manifest_file()
     {
-        $manifest = new IconsManifest(new Filesystem(), $this->manifestPath, []);
-        $manifest->write();
+        $manifest = new IconsManifest(new Filesystem(), $this->manifestPath);
+        $manifest->write([]);
 
         $this->assertTrue(file_exists($this->manifestPath));
         $this->assertTrue($manifest->delete());
@@ -65,10 +64,10 @@ class IconsManifestTest extends TestCase
     /** @test */
     public function it_throws_an_exceptiion_when_the_manifest_path_is_not_present_or_writable()
     {
-        $manifest = new IconsManifest(new Filesystem(), '/foo/bar.php', []);
+        $manifest = new IconsManifest(new Filesystem(), '/foo/bar.php');
 
         try {
-            $manifest->write();
+            $manifest->write([]);
         } catch (Exception $e) {
             $this->assertSame('The /foo directory must be present and writable.', $e->getMessage());
 
@@ -81,8 +80,8 @@ class IconsManifestTest extends TestCase
     /** @test */
     public function it_can_get_the_manifest()
     {
-        $manifest = new IconsManifest(new Filesystem(), $this->manifestPath, []);
+        $manifest = new IconsManifest(new Filesystem(), $this->manifestPath);
 
-        $this->assertSame([], $manifest->getManifest());
+        $this->assertSame([], $manifest->getManifest([]));
     }
 }

--- a/tests/IconsManifestTest.php
+++ b/tests/IconsManifestTest.php
@@ -33,7 +33,7 @@ class IconsManifestTest extends TestCase
         return trim(str_replace(
             '{{ dir }}',
             __DIR__,
-            file_get_contents(__DIR__.'/fixtures/generated-manifest.php')
+            file_get_contents(__DIR__.'/fixtures/generated-manifest.php'),
         ));
     }
 

--- a/tests/IconsManifestTest.php
+++ b/tests/IconsManifestTest.php
@@ -45,7 +45,10 @@ class IconsManifestTest extends TestCase
         $manifest->write();
 
         $this->assertTrue(file_exists($this->manifestPath));
-        $this->assertSame($this->expectedManifest(), file_get_contents($this->manifestPath));
+        $this->assertSame(
+            $this->expectedManifest(),
+            str_replace(" \n", "\n", file_get_contents($this->manifestPath)),
+        );
     }
 
     /** @test */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,7 @@ namespace Tests;
 
 use BladeUI\Icons\BladeIconsServiceProvider;
 use BladeUI\Icons\Factory;
+use BladeUI\Icons\IconsManifest;
 use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithViews;
@@ -17,7 +18,14 @@ abstract class TestCase extends OrchestraTestCase
 
     protected function prepareSets(array $config = [], array $setOptions = []): Factory
     {
-        $factory = (new Factory(new Filesystem(), $this->app->make(FilesystemFactory::class), $config))
+        $factory = new Factory(
+            new Filesystem(),
+            $this->app->make(IconsManifest::class),
+            $this->app->make(FilesystemFactory::class),
+            $config
+        );
+
+        $factory = $factory
             ->add('default', array_merge([
                 'path' => __DIR__.'/resources/svg',
                 'prefix' => 'icon',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -22,7 +22,7 @@ abstract class TestCase extends OrchestraTestCase
             new Filesystem(),
             $this->app->make(IconsManifest::class),
             $this->app->make(FilesystemFactory::class),
-            $config
+            $config,
         );
 
         $factory = $factory

--- a/tests/fixtures/generated-manifest.php
+++ b/tests/fixtures/generated-manifest.php
@@ -1,0 +1,31 @@
+<?php return array (
+  'default' => 
+  array (
+    'prefix' => 'icon',
+    'paths' => 
+    array (
+      0 => '{{ dir }}/resources/svg',
+    ),
+    'icons' => 
+    array (
+      0 => 'camera',
+      1 => 'foo-camera',
+      2 => 'invalid-extension',
+      3 => 'solid.camera',
+      4 => 'xml',
+      5 => 'zondicon-flag',
+    ),
+  ),
+  'zondicons' => 
+  array (
+    'prefix' => 'zondicon',
+    'paths' => 
+    array (
+      0 => '{{ dir }}/resources/zondicons',
+    ),
+    'icons' => 
+    array (
+      0 => 'flag',
+    ),
+  ),
+);

--- a/tests/fixtures/generated-manifest.php
+++ b/tests/fixtures/generated-manifest.php
@@ -1,29 +1,18 @@
 <?php return array (
-  'default' => 
+  'default' =>
   array (
-    'prefix' => 'icon',
-    'paths' => 
-    array (
-      0 => '{{ dir }}/resources/svg',
-    ),
-    'icons' => 
+    '{{ dir }}/resources/svg' =>
     array (
       0 => 'camera',
       1 => 'foo-camera',
-      2 => 'invalid-extension',
-      3 => 'solid.camera',
-      4 => 'xml',
-      5 => 'zondicon-flag',
+      2 => 'solid.camera',
+      3 => 'xml',
+      4 => 'zondicon-flag',
     ),
   ),
-  'zondicons' => 
+  'zondicons' =>
   array (
-    'prefix' => 'zondicon',
-    'paths' => 
-    array (
-      0 => '{{ dir }}/resources/zondicons',
-    ),
-    'icons' => 
+    '{{ dir }}/resources/zondicons' =>
     array (
       0 => 'flag',
     ),


### PR DESCRIPTION
This PR adds a `icons:cache` and `icons:clear` command as well as a manifest implementation. It solves the performance issues when working with large icon sets by caching discovered icons. 

Thanks to @mvdnbrk

Closes https://github.com/blade-ui-kit/blade-icons/issues/71

Todo:
- [x] Write docs