### PR TITLE
Fix component registration when ViewFactory is already resolved

### DIFF
--- a/src/BladeIconsServiceProvider.php
+++ b/src/BladeIconsServiceProvider.php
@@ -24,6 +24,7 @@ final class BladeIconsServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->bootCommands();
+        $this->bootComponents();
         $this->bootDirectives();
         $this->bootIconComponent();
         $this->bootPublishing();
@@ -61,10 +62,6 @@ final class BladeIconsServiceProvider extends ServiceProvider
 
             return $factory;
         });
-
-        $this->callAfterResolving(ViewFactory::class, function ($view, Application $app) {
-            $app->make(Factory::class)->registerComponents();
-        });
     }
 
     private function registerManifest(): void
@@ -91,6 +88,13 @@ final class BladeIconsServiceProvider extends ServiceProvider
                 Console\ClearCommand::class,
             ]);
         }
+    }
+
+    private function bootComponents(): void
+    {
+        $this->callAfterResolving(ViewFactory::class, function ($view, Application $app) {
+            $app->make(Factory::class)->registerComponents();
+        });
     }
 
     private function bootDirectives(): void


### PR DESCRIPTION
This PR move components registration to the service provider's boot method to be sure that all required classes are registered. 

As mentioned in [Laravel's documentation](https://laravel.com/docs/7.x/providers#the-register-method):
> You should never attempt to register any event listeners, routes, or any other piece of functionality within the `register` method. Otherwise, you may accidentally use a service that is provided by a service provider which has not loaded yet.

For example, if `ViewFactory` is already resolved when calling `callAfterResolving`, it will try to register components immediately, but `IconsManifest` is not registered yet. This will the following error as described in #124:

```
Unresolvable dependency resolving [Parameter #1 [ <required> string $manifestPath ]] in class BladeUI\Icons\IconsManifest
```

<!--
Please only send a pull request to the latest release branch.

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; etc.

If applicable, also send a PR to the docs for the new change you're submitting.
-->
