### PR TITLE
making original file info available in callback for adhoc requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,8 @@ First, start off by creating a `generation.php` config file in the `config` dire
 ```php
 <?php
 
+use Symfony\Component\Finder\SplFileInfo;
+
 return [
     [
         // Define a source directory for the sets like a node_modules/ or vendor/ directory...
@@ -544,9 +546,9 @@ return [
         // Enable "safe" mode which will prevent deletion of old icons...
         'safe' => true,
 
-        // Call an optional callback to manipulate the icon
-        // with the pathname of the icon and the settings from above...
-        'after' => static function (string $icon, array $config) {
+        // Call an optional callback to manipulate the icon with the pathname of the icon,
+        // the settings from above and the original icon file instance...
+        'after' => static function (string $icon, array $config, SplFileInfo $file) {
             // ...
         },
     ],

--- a/src/Generation/IconGenerator.php
+++ b/src/Generation/IconGenerator.php
@@ -40,7 +40,7 @@ final class IconGenerator
                 $this->filesystem->copy($file->getRealPath(), $pathname);
 
                 if (is_callable($set['after'] ?? null)) {
-                    $set['after']($pathname, $set);
+                    $set['after']($pathname, $set, $file->getRealPath());
                 }
             }
         }

--- a/src/Generation/IconGenerator.php
+++ b/src/Generation/IconGenerator.php
@@ -40,7 +40,7 @@ final class IconGenerator
                 $this->filesystem->copy($file->getRealPath(), $pathname);
 
                 if (is_callable($set['after'] ?? null)) {
-                    $set['after']($pathname, $set, $file->getRealPath());
+                    $set['after']($pathname, $set, $file);
                 }
             }
         }


### PR DESCRIPTION
@driesvints & @mallardduck ,

There are certain icon-sets which store the icons in the respective folder with the same file name.
Eg:
```
https://github.com/google/material-design-icons/tree/master/src/action/3d_rotation/materialicons/24.svg
```
All the files are named as 24.svg under respective folder with folder having the name of the icon.

From the above example, if I have the original file information available in callback, I can rename the file with an appropriate name using the file object passed in this PR

// from above example, lets say my source directory is `dist/src/action/3d_rotation/materialicons/24.svg`
Following is the callback method configured in `after`
```
$svgNormalization = static function (string $tempFilepath, array $iconSet,  \Symfony\Component\Finder\SplFileInfo $file) {
    ... 
    $fileMeta = explode("/", $file->getRealPath); // eg: dist/src/action/3d_rotation/materialicons/24.svg
    $svgFileName = $fileMeta[count($fileMeta) - 3];
    // now i can use this filename to change the name of the file as I need
    ...
};
```

Your thoughts?