### PR TITLE
Defer icons to icons stack to reduce DOM count

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ When you're using the same icon in lots of places on the page the DOM element co
 To remedy this you can add the defer attribute to the components:
 
 ```blade
-<x-icon-camera :defer="true"/>
+<x-icon-camera defer />
 ```
 
 This will push the icons to the stack "bladeicons", you should load this stack at the bottom of your page

--- a/README.md
+++ b/README.md
@@ -382,6 +382,26 @@ Or any other attributes for that matter:
 
 > ⚠️ Note that with Blade components, using a prefix is always required, even when referencing icons from the default set.
 
+#### Deferring icons
+
+When you're using the same icon in lots of places on the page the DOM element count may explode upwards.
+To remedy this you can add the defer attribute to the components:
+
+```blade
+<x-icon-camera :defer="true"/>
+```
+
+This will push the icons to the stack "bladeicons", you should load this stack at the bottom of your page
+
+```blade
+   ...
+    <svg hidden class="hidden">
+        @stack('bladeicons')
+    </svg>
+</body>
+</html>
+```
+
 #### Default Component
 
 If you don't want to use the component syntax from above you can also make use of the default `Icon` component that ships with Blade Icons. Simply pass the icon name through the `$name` attribute:

--- a/src/Svg.php
+++ b/src/Svg.php
@@ -18,7 +18,7 @@ final class Svg implements Htmlable
     public function __construct(string $name, string $contents, array $attributes = [])
     {
         $this->name = $name;
-        $this->contents = $contents;
+        $this->contents = $this->deferContent($contents, $attributes['defer'] ?? false);
         $this->attributes = $attributes;
     }
 
@@ -39,5 +39,26 @@ final class Svg implements Htmlable
             sprintf('<svg%s', $this->renderAttributes()),
             $this->contents,
         );
+    }
+
+    protected function deferContent($contents, $defer = false)
+    {
+        if (!$defer) {
+            return $contents;
+        }
+
+        $svgContent = strip_tags($contents, ['circle', 'ellipse', 'line', 'path', 'polygon', 'polyline', 'rect']);
+        $hash = 'icon-' . md5($svgContent);
+        $contents = str_replace($svgContent, strtr('<use href=":href"></use>', [':href' => '#' . $hash]), $contents);
+        $contents .= <<<BLADE
+            @once("{$hash}")
+                @push("bladeicons")
+                    <g id="{$hash}">
+                        {$svgContent}
+                    </g>
+                @endpush
+            @endonce
+        BLADE;
+        return $contents;
     }
 }

--- a/src/Svg.php
+++ b/src/Svg.php
@@ -43,22 +43,24 @@ final class Svg implements Htmlable
 
     protected function deferContent($contents, $defer = false)
     {
-        if (!$defer) {
+        if (! $defer) {
             return $contents;
         }
 
         $svgContent = strip_tags($contents, ['circle', 'ellipse', 'line', 'path', 'polygon', 'polyline', 'rect']);
-        $hash = 'icon-' . md5($svgContent);
-        $contents = str_replace($svgContent, strtr('<use href=":href"></use>', [':href' => '#' . $hash]), $contents);
+        $hash = 'icon-'.md5($svgContent);
+        $contents = str_replace($svgContent, strtr('<use href=":href"></use>', [':href' => '#'.$hash]), $contents);
         $contents .= <<<BLADE
-            @once("{$hash}")
-                @push("bladeicons")
-                    <g id="{$hash}">
-                        {$svgContent}
-                    </g>
-                @endpush
-            @endonce
-        BLADE;
+
+                @once("{$hash}")
+                    @push("bladeicons")
+                        <g id="{$hash}">
+                            {$svgContent}
+                        </g>
+                    @endpush
+                @endonce
+            BLADE;
+
         return $contents;
     }
 }

--- a/tests/SvgTest.php
+++ b/tests/SvgTest.php
@@ -26,6 +26,17 @@ class SvgTest extends TestCase
     }
 
     /** @test */
+    public function it_can_compile_to_defered_html()
+    {
+        $svgPath = '<path d="M14 5l7 7m0 0l-7 7m7-7H3"></path>';
+        $svg = new Svg('heroicon-o-arrow-right', '<svg>'.$svgPath.'</svg>', ['defer' => true]);
+
+        $svgHtml = $svg->toHtml();
+        $this->assertStringContainsString('<use href="#icon-'.md5($svgPath).'"></use>', $svgHtml);
+        $this->assertStringContainsString($svgPath, $svgHtml);
+    }
+
+    /** @test */
     public function it_can_compile_with_attributes()
     {
         $svg = new Svg('heroicon-s-camera', '<svg></svg>', ['class' => 'icon', 'style' => 'color: #fff', 'data-foo']);


### PR DESCRIPTION
<!--
Please only send a pull request to the latest release branch.

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; etc.

If applicable, also send a PR to the docs for the new change you're submitting.
-->
This pr allows you to defer the content of SVG elements to drastically reduce DOM element counts for complex icons which are used often on a page.
It's an easier to use alternative to using spritesheets to tackle #185

The way it works is simply by adding an attribute of defer to the icon e.g.
```blade
<x-icon-camera defer />
```

And loading the stack at the bottom of your layout
```blade
   ...
    <svg hidden class="hidden">
        @stack('bladeicons')
    </svg>
</body>
</html>
```

As an example here we're using the larger SVGs of the heroicon pack multiple times
<img width="319" alt="image" src="https://user-images.githubusercontent.com/15870933/162933149-e30024ad-3e35-4589-966e-3af6022921df.png">
The transparent cubes are 1K and the dollar sign is 880B
Loading these in every time we use the icon on a page would result in nearly 6K added to the page which is a lot for a couple of icons.
A category page with products using that icon for it's price might add 24K to the document for 24 paginated products.
Defering these icons will leave that at 1K and only take a couple of bytes for using the icons

In the HTML this will now result in 
![image](https://user-images.githubusercontent.com/15870933/162932065-11d59616-67cf-4091-89ea-5ba7358749d3.png)

This will not break any exising usages of the icon pack since it requires you to add the `defer` attribute manually or add it under `attributes` in `config/blade-icons.php`
