### PR TITLE
feat: ability to use a custom manifest dir

### DIFF
--- a/config/blade-icons.php
+++ b/config/blade-icons.php
@@ -180,4 +180,17 @@ return [
 
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Custom manifest dir
+    |--------------------------------------------------------------------------
+    |
+    | This config option allows you to define a custom manifest dir
+    | by default if not set it uses the application bootstrap dir cache/blade-icons.php
+    | so example you want to use a dir named custom set the value below to 'custom'
+    |
+    */
+
+    'custom_manifest_dir' => null,
+
 ];

--- a/src/BladeIconsServiceProvider.php
+++ b/src/BladeIconsServiceProvider.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\ServiceProvider;
 
 final class BladeIconsServiceProvider extends ServiceProvider
@@ -80,6 +81,13 @@ final class BladeIconsServiceProvider extends ServiceProvider
 
     private function manifestPath(): string
     {
+        $config = $this->app->make('config')->get('blade-icons', []);
+        if (! is_null($customPath = $config['custom_manifest_dir'])) {
+            File::ensureDirectoryExists($customPath);
+
+            return base_path($customPath.'/blade-icons.php');
+        }
+
         return $this->app->bootstrapPath('cache/blade-icons.php');
     }
 


### PR DESCRIPTION
Fixes https://github.com/blade-ui-kit/blade-icons/issues/195

Which will benefit the serverless environment like aws lamda and vapor etc.

This will make use of custom manifest dir if set in the config and will create dir if required.

As it will check null so previous installations will work as it was so keeping the default behavior as it was.

ping @driesvints 
