### PR TITLE
Remove `testing` env check

### DIFF
--- a/src/BladeIconsServiceProvider.php
+++ b/src/BladeIconsServiceProvider.php
@@ -71,7 +71,7 @@ final class BladeIconsServiceProvider extends ServiceProvider
         // intentionally excluded: it only writes the manifest, so pre-registering
         // every component would duplicate the filesystem scan and add thousands of
         // unnecessary Blade::component() calls when large icon packs are installed.
-        if ($this->app->runningInConsole() && ! $this->app->environment('testing')) {
+        if ($this->app->runningInConsole()) {
             $this->app->booted(function (Application $app) {
                 if (in_array($_SERVER['argv'][1] ?? null, ['optimize', 'view:cache'])) {
                     try {


### PR DESCRIPTION
remove `testing` env check when deciding whether to register components (so that `php artisan optimize` works in test environments, e.g. CI)

see https://github.com/driesvints/blade-icons/issues/263